### PR TITLE
Textarea can be too tall or short if textarea width changes

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -186,6 +186,12 @@ angular.module('monospaced.elastic', [])
           forceAdjust();
         });
 
+        scope.$watch(function() {
+          return element.width();
+        }, function(newValue) {
+          forceAdjust();
+        });
+
         scope.$on('elastic:adjust', function() {
           forceAdjust();
         });


### PR DESCRIPTION
Resolves certain issues with textareas that are too tall or too short by adjusting the height when the width of the textarea changes.

I noticed that while a page is loading or under other circumstances where the layout changes, a textarea using `msd-elastic` may be improperly sized. In some cases this may be unavoidable, so it seemed important to watch the width of the textarea and adjust the height accordingly upon detecting a change.
