### PR TITLE
Width and height get readjusted in strange ways when 'computed value' of width is not in pixels

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -115,6 +115,7 @@ angular.module('monospaced.elastic', [])
 
         function adjust() {
           var taHeight,
+              taComputedStyleWidth,
               mirrorHeight,
               width,
               overflow;
@@ -133,8 +134,12 @@ angular.module('monospaced.elastic', [])
             taHeight = ta.style.height === '' ? 'auto' : parseInt(ta.style.height, 10);
 
             // update mirror width in case the textarea width has changed
-            width = parseInt(getComputedStyle(ta).getPropertyValue('width'), 10) - boxOuter.width;
-            mirror.style.width = width + 'px';
+            // (after making sure getComputedStyle has returned a readable 'used value' pixel width)
+            taComputedStyleWidth = getComputedStyle(ta).getPropertyValue('width');
+            if (taComputedStyleWidth.substr(taComputedStyleWidth.length - 2, 2) === "px") {
+              width = parseInt(taComputedStyleWidth, 10) - boxOuter.width;
+              mirror.style.width = width + 'px';
+            }
 
             mirrorHeight = mirror.scrollHeight;
 


### PR DESCRIPTION
When an element is set to "display: none", and it has a percentage width, then that percentage width is returned as a string by window.getComputedValue.getPropertyValue('width'). This can happen in difficult-to-fix race conditions when you have an ng-show directive on the textarea or on one of its parents.

The current behavior (before this pull request) of the adjust function is to run parseInt on the main textarea's percentage width and then apply that number to the width of the mirror textarea with "px" appended to the end, causing weird results. (In our case, it is "96%" when it should be around "600px", so the directive then ends up making the textarea way too high to accommodate a 96px width.)

Better just to not readjust the width, if it cannot be determined. The fix in this pull request solves our problem.
