### PR TITLE
adding offsetHeight for IE only height value

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -67,7 +67,7 @@ angular.module('monospaced.elastic', [])
                                     parseInt(taStyle.getPropertyValue('border-bottom-width'), 10)
                           },
               minHeightValue = parseInt(taStyle.getPropertyValue('min-height'), 10),
-              heightValue = parseInt(taStyle.getPropertyValue('height'), 10),
+              heightValue = ta.currentStyle ? ta.offsetHeight : parseInt(taStyle.getPropertyValue('height'), 10),,
               minHeight = Math.max(minHeightValue, heightValue) - boxOuter.height,
               maxHeight = parseInt(taStyle.getPropertyValue('max-height'), 10),
               mirrored,


### PR DESCRIPTION
.getPropertyValue('height')  in IE was not including borders and padding an was rendering too small on initial page load. Made a change to the the heightValue statement to get a more accurate height on initial render. This change was informed by quirksmode blog article http://www.quirksmode.org/dom/getstyles.html.