### PR TITLE
Minor changes to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ optionally append whitespace to the end of the height calculation (an extra newl
 
 or configure whitespace globally
 
-    app.config(['msdElasticConfig', function(config) {
-      config.append = '\n\n';
+    app.config(['msdElasticConfig', function(msdElasticConfig) {
+      msdElasticConfig.append = '\n';
     }])
 
 Install

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ optionally append whitespace to the end of the height calculation (an extra newl
 or configure whitespace globally
 
     app.config(['msdElasticConfig', function(msdElasticConfig) {
-      msdElasticConfig.append = '\n';
+      msdElasticConfig.append = '\n\n';
     }])
 
 Install


### PR DESCRIPTION
* Renamed `config` variable in  example to decrease confusion.
* Removed repeated \n to match other examples.