### PR TITLE
export module name

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -4,6 +4,10 @@
  * License: MIT
  */
 
+if (typeof module !== "undefined" && typeof exports !== "undefined" && module.exports === exports){
+  module.exports = 'monospaced.elastic';
+}
+
 angular.module('monospaced.elastic', [])
 
   .constant('msdElasticConfig', {


### PR DESCRIPTION
In this way, we can write

```JavaScript
var uiRouter = require('angular-ui-router');
var elastic = require('angular-elastic';

angular
    .module('App.vendor', [
        uiRouter,
       elastic
    ]);
```

instead of the current

```JavaScript
var uiRouter = require('angular-ui-router');
require('angular-elastic';

angular
    .module('App.vendor', [
        uiRouter,
       'monospaced.elastic'
    ]);
```