### PR TITLE
Emits resize event before changing the elements height

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-elastic",
-  "version": "2.4.2",
+  "name": "angular-elastic-extension",
+  "version": "2.4.3",
   "main": "elastic.js",
   "ignore": [
     "**/.*",

--- a/elastic.js
+++ b/elastic.js
@@ -157,8 +157,8 @@ angular.module('monospaced.elastic', [])
               ta.style.overflowY = overflow || 'hidden';
 
               if (taHeight !== mirrorHeight) {
+                scope.$emit('elastic:resize', $ta, taHeight, mirrorHeight);
                 ta.style.height = mirrorHeight + 'px';
-                scope.$emit('elastic:resize', $ta);
               }
 
               // small delay to prevent an infinite loop

--- a/elastic.js
+++ b/elastic.js
@@ -1,5 +1,5 @@
 /*
- * angular-elastic v2.4.2
+ * angular-elastic v2.4.3
  * (c) 2014 Monospaced http://monospaced.com
  * License: MIT
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "angular-elastic",
-  "version": "2.4.2",
+  "name": "angular-elastic-extension",
+  "version": "2.4.3",
   "description": "Elastic (autosize) textareas for AngularJS, without jQuery dependency.",
   "keywords": [
     "angular",


### PR DESCRIPTION
Also include value of the new height.
This allows eventListeners to have more flexibility to deal with the new height, e.g.
```javascript
$scope.$on('elastic:resize', function(event, element, oldHeight, newHeight) {
    // do stuff
});
```