### PR TITLE
Emits resize event before changing the elements height

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -157,8 +157,8 @@ angular.module('monospaced.elastic', [])
               ta.style.overflowY = overflow || 'hidden';
 
               if (taHeight !== mirrorHeight) {
+                scope.$emit('elastic:resize', $ta, taHeight, mirrorHeight);
                 ta.style.height = mirrorHeight + 'px';
-                scope.$emit('elastic:resize', $ta);
               }
 
               // small delay to prevent an infinite loop


### PR DESCRIPTION
Also include value of the new height.
This allows eventListeners to have more flexibility to deal with the new height, e.g.
```javascript
$scope.$on('elastic:resize', function(event, element, oldHeight, newHeight) {
    // do stuff
});
```