### PR TITLE
Sending in invokeApply=false flag to $timeout

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -164,7 +164,7 @@ angular.module('monospaced.elastic', [])
               // small delay to prevent an infinite loop
               $timeout(function() {
                 active = false;
-              }, 1);
+              }, 1, false);
 
             }
           }
@@ -199,7 +199,7 @@ angular.module('monospaced.elastic', [])
             forceAdjust();
           });
 
-          $timeout(adjust);
+          $timeout(adjust, 0, false);
 
           /*
            * destroy


### PR DESCRIPTION
Sending in invokeApply=false flag to the $timeout service to prevent a digest loop from being triggered. Since the adjust function only appears to calculate and set css and doesn't perform any model changes there shouldn't be any need to trigger a digest loop. This improves the performance.