### PR TITLE
copy padding to hidden textarea

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -84,6 +84,7 @@ angular.module('monospaced.elastic', [])
                            'font-style',
                            'letter-spacing',
                            'line-height',
+                           'padding',
                            'text-transform',
                            'word-spacing',
                            'text-indent'];


### PR DESCRIPTION
In chrome width setted incorectly, this patch fixing it.
But still has problem on mobile chrome.
