### PR TITLE
callback called when textarea's height updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ the directive also emits an `elastic:resize` event which you can listen for
 Single line textareas
 --------------
 
-Set the `rows` attribute to `1`, as browsers default to `2`.
+Set the `rows` attribute to `1`, as browsers default to `2`. The `callback()` is called every time the `textarea`'s height updates.
 
-    <textarea rows="1" msd-elastic ng-model="foo">
+    <textarea rows="1" msd-elastic msd-elastic-change="callback()" ng-model="foo">
       ...
     </textarea>
 

--- a/elastic.js
+++ b/elastic.js
@@ -24,7 +24,9 @@ angular.module('monospaced.elastic', [])
       return {
         require: 'ngModel',
         restrict: 'A, C',
-        link: function(scope, element, attrs, ngModel) {
+        scope: {
+          msdElasticChange: '&'
+        }, link: function(scope, element, attrs, ngModel) {
 
           // cache a reference to the DOM element
           var ta = element[0],
@@ -164,7 +166,9 @@ angular.module('monospaced.elastic', [])
 
               if (taHeight !== mirrorHeight) {
                 scope.$emit('elastic:resize', $ta, taHeight, mirrorHeight);
+                var trigger = (ta.style.height != mirrorHeight + 'px');
                 ta.style.height = mirrorHeight + 'px';
+                if (trigger) scope.msdElasticChange();
               }
 
               // small delay to prevent an infinite loop


### PR DESCRIPTION
It was very useful to me in my chat application, where the size of the rest of the page was relative to the size of the textarea's input. So I've used the callback to update the height of the rest of the page only when the textarea's height updated.