### PR TITLE
fix FF60+ scroll bug on site search

### DIFF
--- a/elastic.js
+++ b/elastic.js
@@ -53,6 +53,7 @@ angular.module('monospaced.elastic', [])
                                 'left: 0; overflow: hidden; -webkit-box-sizing: content-box;' +
                                 '-moz-box-sizing: content-box; box-sizing: content-box;' +
                                 'min-height: 0 !important; height: 0 !important; padding: 0;' +
+                                'visibility: hidden;' +  // fix FF60+ scroll bug
                                 'word-wrap: break-word; border: 0;',
               $mirror = angular.element('<textarea aria-hidden="true" tabindex="-1" ' +
                                         'style="' + mirrorInitStyle + '"/>').data('elastic', true),


### PR DESCRIPTION
Firefox 60+ needs hidden elements to exclude them in site search.
Otherwise, seeking next term occurrence jumps scroll to the top.  This
seems to be a FF bug.
